### PR TITLE
Fix double parsing bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ SonoffAccessory.prototype.getState = function(callback) {
   .end((error, response) => {
     if (!error && response.statusCode == 200) {
       var json = JSON.parse(response.text).data;
-      var state = JSON.parse(json).switch;
+      var state = json.switch;
 
       if (this.debug)           
           this.log('getState() request returned successfully ('+response.statusCode+'). Body: '+JSON.stringify(json));


### PR DESCRIPTION
With the fix the plugin is now usable with homebridge. Before that I got the message `SyntaxError: Unexpected token o in JSON at position 1` which caused a SIGINT in homebridge.